### PR TITLE
made team name fix

### DIFF
--- a/api_types.go
+++ b/api_types.go
@@ -163,6 +163,7 @@ type LeagueTable struct {
 
 // Contains statistical information about a team's performance in a league.
 type TeamLeagueStatistics struct {
+	Team           string
 	CrestURI       string
 	Draws          uint16
 	GoalDifference int16
@@ -172,7 +173,6 @@ type TeamLeagueStatistics struct {
 	PlayedGames    uint8
 	Points         uint16
 	Position       uint8
-	TeamName       string
 	Wins           uint16
 	Home           ShortTeamLeagueStatistics
 	Away           ShortTeamLeagueStatistics


### PR DESCRIPTION
So @icedream I dig more deeper and found out that the team name and crest uri for some teams like "Reading" are both set to null and it's not after decoding, if you place a fmt.Println() on the buffer that is present inside the doJson() method i.e the result being returned from the get request you will see that the team and crest uri attribute are both being set to null for some teams, so my guess is there is something wrong with the football.org REST API and for some reason instead of sending the team name inside of TeamName attribute, it sends team name in team attribute, so for now that is the only fix, I have pushed with this branch because from my research it seems there isn't any problem with your code. Let me know if there is anything else that I can work on cheers.